### PR TITLE
Remove slashes in uids, to prevent 404

### DIFF
--- a/ics2owncloud.py
+++ b/ics2owncloud.py
@@ -39,6 +39,7 @@ def do_import(username, password, calendar, server, ics_url):
   imported_uids = []
   for e in c.walk('VEVENT'):
     uid = e['UID'].to_ical()
+    uid = uid.replace('/','slash')
     cal = Calendar()
     cal.add_component(e)
     r = requests.put('%s/%s.ics' % (base_url, uid),


### PR DESCRIPTION
There is a problem, where that if a uid includes a slash, it fails with the error message "HTTPError: 404 Client Error: Not Found for url: https://owncloud/remote.php/dav/calendars/user/calendar/uid" this can be prevented by replacing all slashes, in the uids